### PR TITLE
Feature/fix read booking fields in response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/api/bookings/read.php
+++ b/api/bookings/read.php
@@ -35,7 +35,6 @@ if($num > 0) {
       'customer_id' => $customer_id,
       'guest_nr' => $guest_nr,
       'date' => $date,
-      'id' => $id,
       'name' => $name,
       'lastname' => $lastname,
       'email' => $email,
@@ -51,13 +50,13 @@ if($num > 0) {
 
   //Turn to JSON & output
   echo json_encode($booking_arr);
-  } else {  
-  
+  } else {
+
   // set response code - 404 not found
   http_response_code(404);
 
   echo json_encode(
-    
+
     array('message' => 'No Bookings Found')
   );
 }

--- a/models/Booking.php
+++ b/models/Booking.php
@@ -20,7 +20,9 @@
     public function read() {
       // Create query
       $query = (
-        'SELECT * FROM Booking
+        'SELECT Booking.id, Booking.customer_id, Booking.guest_nr, Booking.date, 
+         Customer.name, Customer.lastname, Customer.email, Customer.phone 
+         FROM Booking
          LEFT JOIN Customer ON Booking.customer_id = Customer.id'
       );
 
@@ -36,7 +38,9 @@
     // Read single booking
       public function readSingle($id) {
         $query = (
-            'SELECT * FROM Booking
+            'SELECT Booking.id, Booking.customer_id, Booking.guest_nr, Booking.date, 
+             Customer.name, Customer.lastname, Customer.email, Customer.phone
+             FROM Booking
              LEFT JOIN Customer ON Booking.customer_id = Customer.id
              WHERE Booking.id = :id');
 
@@ -60,10 +64,10 @@
           guest_nr = :guest_nr,
           date = :date;
           ';
-          
+
       // Prepare statement
       $stmt = $this->conn->prepare($query);
-      
+
 
       //Clean data
       $this->customer_id = htmlspecialchars(strip_tags($this->customer_id));


### PR DESCRIPTION
Removed duplicate array key from booking_item so the id doesn't get overwritten. 

Changed the query statements for 'read' and 'read single' to not retrieve the column 'id' from the customer table so the response doesn't have a duplicate field.  